### PR TITLE
Revert "Add basic error handling"

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,7 +5,6 @@ import (
 	"crypto/ed25519"
 	"encoding/base32"
 	"fmt"
-	"log"
 	"os"
 	"regexp"
 	"runtime"
@@ -16,16 +15,12 @@ import (
 	"golang.org/x/crypto/sha3"
 )
 
-func generate(wg *sync.WaitGroup, re *regexp.Regexp) error {
+func generate(wg *sync.WaitGroup, re *regexp.Regexp) {
 
 	for {
 
 		// Generate key pair
-		publicKey, _, err := ed25519.GenerateKey(nil)
-		if err != nil {
-			wg.Done()
-			return err
-		}
+		publicKey, _, _ := ed25519.GenerateKey(nil)
 
 		// checksum = H(".onion checksum" || pubkey || version)
 		var checksumBytes bytes.Buffer
@@ -44,48 +39,29 @@ func generate(wg *sync.WaitGroup, re *regexp.Regexp) error {
 		// If a matching address is found, save key and notify wait group
 		if re.MatchString(onionAddress) == true {
 			fmt.Println(strings.ToLower(onionAddress) + ".onion")
+			wg.Done()
 		}
-
-		wg.Done()
-		return nil
 	}
-
 }
 
 func main() {
-
-	// Check if arguments were provided.
-	if len(os.Args[1]) == 0 || len(os.Args[2]) == 0 {
-		fmt.Print("please provide a <regex> and a <number>")
-		os.Exit(1)
-	}
 
 	// Set runtime to use all available CPUs.
 	runtime.GOMAXPROCS(runtime.NumCPU())
 
 	// Compile regex from first argument.
-	re, err := regexp.Compile(os.Args[1])
-	if err != nil {
-		log.Fatalf("error compiling regex: %v", err)
-	}
+	re, _ := regexp.Compile(os.Args[1])
 
 	// Get the number of desired addreses from second argument.
-	numAddresses, err := strconv.Atoi(os.Args[2])
-	if err != nil {
-		log.Fatalf("error converting string to int: %v", err)
-	}
+	numAddresses, _ := strconv.Atoi(os.Args[2])
 
-	// WaitGroup of size equal to desired number of addresses.
+	// WaitGroup of size equal to desired number of addresses
 	var wg sync.WaitGroup
 	wg.Add(numAddresses)
 
-	// For each CPU, run a generate goroutine.
-	errChan := make(chan error, 1)
+	// For each CPU, run a generate goroutine
 	for i := 0; i < runtime.NumCPU(); i++ {
-		go func() { errChan <- generate(&wg, re) }()
-	}
-	if err = <-errChan; err != nil {
-		log.Fatalf("error generating onion address: %v", err)
+		go generate(&wg, re)
 	}
 
 	// Exit after the desired number of addresses have been found.


### PR DESCRIPTION
Reverts rdkr/oniongen-go#5

reverting this, as it doesn't seem to work as expected. cc @ciehanski.

if there is not an error we always call wg.Done(), so after generate() has run NumCPU() the workgroup is done but we do not necessarily have the desired number of addresses.