### PR TITLE
fix: set module name to github repo:

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module oniongen-go
+module github.com/rdkr/oniongen-go
 
 go 1.14
 


### PR DESCRIPTION
this will mean that you will be able to run `go install github.com/rdkr/oniongen-go@latest` to install a binary to `$GOPATH/bin/oniongen-go`.

at the moment you get this from `go install`:

```
➜ go install github.com/rdkr/oniongen-go@latest
go: github.com/rdkr/oniongen-go@latest: github.com/rdkr/oniongen-go@v0.0.0-20220303205746-8fbf8d70c9e5: parsing go.mod:
        module declares its path as: oniongen-go
                but was required as: github.com/rdkr/oniongen-go
```

see [here](https://go.dev/ref/mod#module-path) for the relevant part of the Go Modules documentation.

thanks for the great program!